### PR TITLE
Missing px unit

### DIFF
--- a/js/progressive-image-loading.js
+++ b/js/progressive-image-loading.js
@@ -27,7 +27,7 @@
         maxWidth = aspectRatioPlaceholder.offsetWidth,
         maxHeight = aspectRatioPlaceholder.offsetHeight;
 
-        aspectRatioPlaceholder.setAttribute('style', 'max-width:'+maxWidth+'; max-height:'+maxHeight+';');
+        aspectRatioPlaceholder.setAttribute('style', 'max-width:'+maxWidth+'px; max-height:'+maxHeight+'px;');
 
 
         // get thumbnail height wight


### PR DESCRIPTION
Chrome shows CSS warnings because they unit is missing
